### PR TITLE
Optimize create_screen

### DIFF
--- a/src/scbuf.c
+++ b/src/scbuf.c
@@ -132,8 +132,8 @@ int create_screen(SCREENCELL **newScreen){
        temp.foreColor = F_WHITE; 
      for(i = 0; i < buffersize; i++) {
       //Except for their index
-      temp.index = i;
-      *aux = addend(*aux, newelement(temp)); 
+      temp.index = buffersize - 1 - i;
+      *aux = addfront(*aux, newelement(temp)); 
      }
      return 1; 
    } else{


### PR DESCRIPTION
I noticed it took more time than I would expect for c-edit to start up. Looking into it with `valgrind --tool=callgrind` pointed me to the `addend` function called from `create_screen`. 

Repeatedly calling `addend` unnecessarily traverses the linked list a lot of times. Instead call `addfront` which does not traverse the list.

This changes the time complexity of `create_screen` from O(n^2) to O(n).